### PR TITLE
handle missing rbenv-aliases plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 
--
+- handle missing rbenv-aliases plugin
 
 
 ## 0.8.2 - 2023-07-13

--- a/lib/gemika/matrix.rb
+++ b/lib/gemika/matrix.rb
@@ -1,3 +1,4 @@
+require 'open3'
 require 'yaml'
 require 'gemika/errors'
 require 'gemika/env'
@@ -89,11 +90,15 @@ module Gemika
       end
 
       ##
-      # Returns the list of rbenv aliases, if rbenv is installed.
+      # Returns the list of rbenv aliases, if rbenv is installed with rbenv-aliases plugin.
       #
       def rbenv_aliases
-        if `which rbenv` != ''
-          `rbenv alias --list`
+        _output, status = Open3.capture2e('which', 'rbenv')
+        return '' unless status.success?
+
+        output, status = Open3.capture2e('rbenv', 'alias', '--list')
+        if status.success?
+          output
         else
           ''
         end

--- a/spec/gemika/matrix/row_spec.rb
+++ b/spec/gemika/matrix/row_spec.rb
@@ -57,6 +57,19 @@ describe Gemika::Matrix::Row do
       end
     end
 
+    context 'when rbenv is installed without rbenv-aliases plugin' do
+      before do
+        allow(Open3).to receive(:capture2e).with('which', 'rbenv').and_return(['/path/to/rbenv', double(success?: true, exitstatus: 0)])
+        allow(Open3).to receive(:capture2e).with('rbenv', 'alias', '--list').and_return(['rbenv: no such command `alias', double(success?: false, exitstatus: 1)])
+      end
+
+      it 'does not crash and does not print errors' do
+        expect do
+          expect(subject.compatible_with_ruby?('3.0.3')).to eq(true)
+        end.to output('').to_stdout_from_any_process.and output('').to_stderr_from_any_process
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
@evman182 had an issue when rbenv was installed without rbenv-aliases, see https://github.com/makandra/gemika/pull/13#discussion_r1440087366

Did you experience a real problem? It looks like the missing plugin just caused `rbenv: no such command `alias'` to be printed to stderr.